### PR TITLE
Add grokbot-tui

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   <a href="https://awesome.re"><img src="https://awesome.re/badge.svg" alt="Awesome" /></a>
-  <img src="https://img.shields.io/badge/entries-165-blueviolet" alt="Entry count" />
+  <img src="https://img.shields.io/badge/entries-166-blueviolet" alt="Entry count" />
   <img src="https://img.shields.io/badge/Grok%20Bot-beta%20(2026--08--11)-informational" alt="Grok Bot status" />
   <img src="https://img.shields.io/badge/license-CC0-lightgrey" alt="License" />
 </p>
@@ -186,6 +186,7 @@
 - [Grok Bot Telegram bridge](https://github.com/SSBrouhard/grokbot-telegram-bridge) - 非公式の Telegram ブリッジ。Grok Bot のクラウドパソコン内で動き、ループバックの Sand ゲートウェイとだけ話します。
 - [grok-wechat-plugin](https://github.com/little-thing/grok-wechat-plugin) - 非公式の WeChat iLink チャネル。着信は webhook で Grok Bot の routine を起こします。
 - [grok-bot-cli](https://github.com/ScriptedAlchemy/grok-bot-cli) - サインイン済み macOS アプリを使い、端末から Bot の一覧・作成・送信をする CLI。
+- [grokbot-tui](https://github.com/smarzban/grokbot-tui) - いつものターミナルから Bot とチャンネルにチャットする TUI。
 - [grok-bot-skill](https://github.com/adamanz/grok-bot-skill) - Cursor/Claude 用スキル。Grok Bot の一覧、会話、作成ができる。
 - [budezllc/dictate-capture](https://github.com/budezllc/dictate-capture) - Windows 用。Ctrl+D を押しながら Grok Bot に口述し、金色の枠をドラッグするとスクショも貼る。
 - [HAEGONG/grok-bot-profiles](https://github.com/HAEGONG/grok-bot-profiles) - 貼り付け用の Grok Bot プロファイル。仕様・再現・実装・検証を分け、自分の成果を自分で承認させない。
@@ -278,7 +279,7 @@
 
 ## 貢献
 
-8 セクションに 165 件を収録しています。PR の前に [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) を読んでください。対象はクラウドパソコン仲間としての Grok Bot、リンクは開けること、説明は句点で終わる一文です。
+8 セクションに 166 件を収録しています。PR の前に [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) を読んでください。対象はクラウドパソコン仲間としての Grok Bot、リンクは開けること、説明は句点で終わる一文です。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   <a href="https://awesome.re"><img src="https://awesome.re/badge.svg" alt="Awesome" /></a>
-  <img src="https://img.shields.io/badge/entries-165-blueviolet" alt="Entry count" />
+  <img src="https://img.shields.io/badge/entries-166-blueviolet" alt="Entry count" />
   <img src="https://img.shields.io/badge/Grok%20Bot-beta%20(2026--08--11)-informational" alt="Grok Bot status" />
   <img src="https://img.shields.io/badge/license-CC0-lightgrey" alt="License" />
 </p>
@@ -186,6 +186,7 @@
 - [Grok Bot Telegram bridge](https://github.com/SSBrouhard/grokbot-telegram-bridge) - Unofficial Telegram gateway that runs on the Grok Bot computer and talks to the local Sand gateway on loopback only.
 - [grok-wechat-plugin](https://github.com/little-thing/grok-wechat-plugin) - Unofficial WeChat iLink channel: inbound messages wake a Grok Bot routine over webhook.
 - [grok-bot-cli](https://github.com/ScriptedAlchemy/grok-bot-cli) - Terminal CLI that reuses the signed-in macOS Grok Bot app to list, create, and message teammates.
+- [grokbot-tui](https://github.com/smarzban/grokbot-tui) - Terminal TUI to chat with your bots and channels from the terminal you already work in.
 - [grok-bot-skill](https://github.com/adamanz/grok-bot-skill) - Cursor/Claude skill so a coding agent can list, chat with, and create Grok Bot teammates.
 - [budezllc/dictate-capture](https://github.com/budezllc/dictate-capture) - Windows helper: hold Ctrl+D to dictate into Grok Bot, optionally drag a gold box to paste a screenshot.
 - [HAEGONG/grok-bot-profiles](https://github.com/HAEGONG/grok-bot-profiles) - Paste-in Grok Bot profiles that split spec, bug repro, implementation, and verification so a bot never approves its own work.
@@ -278,7 +279,7 @@
 
 ## Contributing
 
-165 curated entries across 8 sections. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR: the resource must be about Grok Bot the cloud-computer teammate, the link must work, and the blurb is one sentence ending with a period.
+166 curated entries across 8 sections. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR: the resource must be about Grok Bot the cloud-computer teammate, the link must work, and the blurb is one sentence ending with a period.
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   <a href="https://awesome.re"><img src="https://awesome.re/badge.svg" alt="Awesome" /></a>
-  <img src="https://img.shields.io/badge/entries-165-blueviolet" alt="Entry count" />
+  <img src="https://img.shields.io/badge/entries-166-blueviolet" alt="Entry count" />
   <img src="https://img.shields.io/badge/Grok%20Bot-beta%20(2026--08--11)-informational" alt="Grok Bot status" />
   <img src="https://img.shields.io/badge/license-CC0-lightgrey" alt="License" />
 </p>
@@ -186,6 +186,7 @@
 - [Grok Bot Telegram bridge](https://github.com/SSBrouhard/grokbot-telegram-bridge) - 非官方 Telegram 网关：跑在 Grok Bot 云电脑里，只跟本机 Sand 网关走回环。.
 - [grok-wechat-plugin](https://github.com/little-thing/grok-wechat-plugin) - 非官方微信 iLink 渠道：入站消息走 webhook 唤醒 Grok Bot 例程。.
 - [grok-bot-cli](https://github.com/ScriptedAlchemy/grok-bot-cli) - 复用已登录 macOS Grok Bot 应用，在终端列出、创建、给队友发消息。.
+- [grokbot-tui](https://github.com/smarzban/grokbot-tui) - 终端 TUI：在你已经在用的终端里和 bots、频道聊天。.
 - [grok-bot-skill](https://github.com/adamanz/grok-bot-skill) - Cursor/Claude 技能，让编程助手能列出、对话、创建 Grok Bot 队友。.
 - [budezllc/dictate-capture](https://github.com/budezllc/dictate-capture) - Windows 辅助：按住 Ctrl+D 对着 Grok Bot 说话，再拖一个金框就能贴截图。.
 - [HAEGONG/grok-bot-profiles](https://github.com/HAEGONG/grok-bot-profiles) - 可粘贴的 Grok Bot 人设：规格、复现、实现、验收分开，Bot 不能给自己过审。.
@@ -278,7 +279,7 @@
 
 ## 贡献
 
-目前 8 个分类、165 条精选。提交前请读 [CONTRIBUTING.md](CONTRIBUTING.md)：必须是云电脑队友这个产品、链接能打开、一句话说明、句号结尾。
+目前 8 个分类、166 条精选。提交前请读 [CONTRIBUTING.md](CONTRIBUTING.md)：必须是云电脑队友这个产品、链接能打开、一句话说明、句号结尾。
 
 ---
 

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -926,6 +926,16 @@
           }
         },
         {
+          "title": "grokbot-tui",
+          "url": "https://github.com/smarzban/grokbot-tui",
+          "source": "day-20260828",
+          "blurb": {
+            "en": "Terminal TUI to chat with your bots and channels from the terminal you already work in.",
+            "zh": "终端 TUI：在你已经在用的终端里和 bots、频道聊天。",
+            "ja": "いつものターミナルから Bot とチャンネルにチャットする TUI。"
+          }
+        },
+        {
           "title": "grok-bot-skill",
           "url": "https://github.com/adamanz/grok-bot-skill",
           "source": "day-20260823",


### PR DESCRIPTION
## New resource

- [grokbot-tui](https://github.com/smarzban/grokbot-tui) - Terminal TUI to chat with your bots and channels from the terminal you already work in.

## Checklist

- [x] About Grok Bot the cloud-computer teammate (not grok.com chat / Imagine / 4.x)
- [x] I opened the link
- [x] `data/catalog.json` has `en` + `zh` + `ja` blurbs
- [x] `python3 scripts/generate_readme.py` was run
- [x] No duplicate URL
