### PR TITLE
catalog: add AskGrokWallet (governed-wallet plugin for Grok Bot)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   <a href="https://awesome.re"><img src="https://awesome.re/badge.svg" alt="Awesome" /></a>
-  <img src="https://img.shields.io/badge/entries-400-blueviolet" alt="Entry count" />
+  <img src="https://img.shields.io/badge/entries-401-blueviolet" alt="Entry count" />
   <img src="https://img.shields.io/badge/Grok%20Bot-beta%20(2026--08--11)-informational" alt="Grok Bot status" />
   <img src="https://img.shields.io/badge/license-CC0-lightgrey" alt="License" />
 </p>
@@ -290,6 +290,7 @@
 - [Peekaboo Mac UI skill](https://github.com/bcharleson/grokbot-peekaboo) - 登録済み Mac を Peekaboo 経由で操作する Grok Bot スキルで、録画・スクショ・ウィンドウ一覧・UI 入力を bash 以上に拡張します。
 - [awesome-claude-skills port for Grok Bot](https://github.com/jeremybrasher/grokbot-skills) - awesome-claude-skills を Grok Bot 向けに再構成した大規模スキル集で、元ライセンスと SOURCE.md を保った1スキル1フォルダ構成です。
 - [grok-bot-rooms registry plugin](https://github.com/mrlynn/grok-bot-plugin-example) - リポジトリ名 grok-bot-plugin-example の Agent プラグインで、Grok Bot 向けにアシスタント登録・ルームチェックイン・スラッシュコマンド・ホスト招待ロビーを提供します。
+- [AskGrokWallet](https://github.com/richard7463/askgrokwallet) - Grok Bot 向けの管理型ウォレットプラグインで、平易なポリシーを allow/ask/deny に変換し、「ask」は人の承認ボックスへ、すべての結果に署名済みレシートを残し、オンチェーンエンジンは ERC-8196 を実装して Base メインネットにデプロイされています（MIT）。
 
 ## レビューと比較
 
@@ -504,7 +505,7 @@
 
 ## 貢献
 
-8 セクションに 400 件を収録しています。PR の前に [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) を読んでください。対象はクラウドパソコン仲間としての Grok Bot、リンクは開けること、説明は句点で終わる一文です。
+8 セクションに 401 件を収録しています。PR の前に [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) を読んでください。対象はクラウドパソコン仲間としての Grok Bot、リンクは開けること、説明は句点で終わる一文です。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   <a href="https://awesome.re"><img src="https://awesome.re/badge.svg" alt="Awesome" /></a>
-  <img src="https://img.shields.io/badge/entries-400-blueviolet" alt="Entry count" />
+  <img src="https://img.shields.io/badge/entries-401-blueviolet" alt="Entry count" />
   <img src="https://img.shields.io/badge/Grok%20Bot-beta%20(2026--08--11)-informational" alt="Grok Bot status" />
   <img src="https://img.shields.io/badge/license-CC0-lightgrey" alt="License" />
 </p>
@@ -290,6 +290,7 @@
 - [Peekaboo Mac UI skill](https://github.com/bcharleson/grokbot-peekaboo) - Grok Bot skill that drives registered Macs through Peekaboo for screen recording, screenshots, window lists, and UI input beyond plain bash.
 - [awesome-claude-skills port for Grok Bot](https://github.com/jeremybrasher/grokbot-skills) - Large Grok Bot skill collection reshaped from awesome-claude-skills, keeping original licenses and SOURCE.md links in one-folder-per-skill layout.
 - [grok-bot-rooms registry plugin](https://github.com/mrlynn/grok-bot-plugin-example) - Agent Plugin (repo slug grok-bot-plugin-example) that registers assistants into hosted rooms, check-ins, slash commands, and host-and-invite lobbies for Grok Bot.
+- [AskGrokWallet](https://github.com/richard7463/askgrokwallet) - Governed-wallet plugin for Grok Bot: plain-English policies compile to allow/ask/deny, "ask" lands in a human approval inbox, and every outcome leaves a signed receipt; the onchain engine implements ERC-8196 on Base mainnet (MIT).
 
 ## Reviews & Comparisons
 
@@ -504,7 +505,7 @@
 
 ## Contributing
 
-400 curated entries across 8 sections. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR: the resource must be about Grok Bot the cloud-computer teammate, the link must work, and the blurb is one sentence ending with a period.
+401 curated entries across 8 sections. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR: the resource must be about Grok Bot the cloud-computer teammate, the link must work, and the blurb is one sentence ending with a period.
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   <a href="https://awesome.re"><img src="https://awesome.re/badge.svg" alt="Awesome" /></a>
-  <img src="https://img.shields.io/badge/entries-400-blueviolet" alt="Entry count" />
+  <img src="https://img.shields.io/badge/entries-401-blueviolet" alt="Entry count" />
   <img src="https://img.shields.io/badge/Grok%20Bot-beta%20(2026--08--11)-informational" alt="Grok Bot status" />
   <img src="https://img.shields.io/badge/license-CC0-lightgrey" alt="License" />
 </p>
@@ -290,6 +290,7 @@
 - [Peekaboo Mac UI skill](https://github.com/bcharleson/grokbot-peekaboo) - Grok Bot 技能：经 Peekaboo 驱动已注册 Mac，完成录屏、截图、窗口列表与 UI 输入，补足纯 bash 不足。.
 - [awesome-claude-skills port for Grok Bot](https://github.com/jeremybrasher/grokbot-skills) - 从 awesome-claude-skills 改编的大型 Grok Bot 技能合集，保留原许可证与 SOURCE.md，一技能一目录。.
 - [grok-bot-rooms registry plugin](https://github.com/mrlynn/grok-bot-plugin-example) - Agent 插件（仓库名 grok-bot-plugin-example）为 Grok Bot 提供助手登记、房间签到、斜杠命令与主持邀请大厅。.
+- [AskGrokWallet](https://github.com/richard7463/askgrokwallet) - 面向 Grok Bot 的受治理钱包插件：大白话规则编译成放行/询问/拒绝，“询问”进入人工审批台，每笔结果留下签名回执；链上引擎实现 ERC-8196，部署在 Base 主网（MIT）。.
 
 ## 评测与对比
 
@@ -504,7 +505,7 @@
 
 ## 贡献
 
-目前 8 个分类、400 条精选。提交前请读 [CONTRIBUTING.md](CONTRIBUTING.md)：必须是云电脑队友这个产品、链接能打开、一句话说明、句号结尾。
+目前 8 个分类、401 条精选。提交前请读 [CONTRIBUTING.md](CONTRIBUTING.md)：必须是云电脑队友这个产品、链接能打开、一句话说明、句号结尾。
 
 ---
 

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -2054,6 +2054,16 @@
             "zh": "Agent 插件（仓库名 grok-bot-plugin-example）为 Grok Bot 提供助手登记、房间签到、斜杠命令与主持邀请大厅。",
             "ja": "リポジトリ名 grok-bot-plugin-example の Agent プラグインで、Grok Bot 向けにアシスタント登録・ルームチェックイン・スラッシュコマンド・ホスト招待ロビーを提供します。"
           }
+        },
+        {
+          "title": "AskGrokWallet",
+          "url": "https://github.com/richard7463/askgrokwallet",
+          "source": "GB-451",
+          "blurb": {
+            "en": "Governed-wallet plugin for Grok Bot: plain-English policies compile to allow/ask/deny, \"ask\" lands in a human approval inbox, and every outcome leaves a signed receipt; the onchain engine implements ERC-8196 on Base mainnet (MIT).",
+            "zh": "面向 Grok Bot 的受治理钱包插件：大白话规则编译成放行/询问/拒绝，“询问”进入人工审批台，每笔结果留下签名回执；链上引擎实现 ERC-8196，部署在 Base 主网（MIT）。",
+            "ja": "Grok Bot 向けの管理型ウォレットプラグインで、平易なポリシーを allow/ask/deny に変換し、「ask」は人の承認ボックスへ、すべての結果に署名済みレシートを残し、オンチェーンエンジンは ERC-8196 を実装して Base メインネットにデプロイされています（MIT）。"
+          }
         }
       ]
     },


### PR DESCRIPTION
Adds [AskGrokWallet](https://github.com/richard7463/askgrokwallet) to Skills, Plugins & MCP.

- Grok Bot governed-wallet plugin: plain-English policies compile to allow/ask/deny, "ask" lands in a human approval inbox, and every outcome leaves a signed receipt. Onchain engine implements ERC-8196 on Base mainnet (MIT).
- Link verified: repo live; xAI marketplace PR [#341](https://github.com/xai-org/plugin-marketplace/pull/341) open.
- Added blurb in en/zh/ja to `data/catalog.json` and regenerated README.md / README.zh.md / README.ja.md via `scripts/generate_readme.py`.

Checklist:
- [x] Entry is about Grok Bot the product
- [x] URL reachable and opened
- [x] One-sentence blurbs (en/zh/ja), ending with period
- [x] Lands in the closest section (Skills, Plugins & MCP)
- [x] `data/catalog.json` updated + READMEs regenerated