### PR TITLE
catalog: re-add Bot Shelf (live USDT checkout blurb)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   <a href="https://awesome.re"><img src="https://awesome.re/badge.svg" alt="Awesome" /></a>
-  <img src="https://img.shields.io/badge/entries-555-blueviolet" alt="Entry count" />
+  <img src="https://img.shields.io/badge/entries-556-blueviolet" alt="Entry count" />
   <img src="https://img.shields.io/badge/Grok%20Bot-beta%20(2026--08--11)-informational" alt="Grok Bot status" />
   <img src="https://img.shields.io/badge/license-CC0-lightgrey" alt="License" />
 </p>
@@ -234,6 +234,7 @@
 
 ## スキル、プラグインと MCP
 
+- [Bot Shelf](https://github.com/getbotshelf/botshelf) - すでに走った Grok Bot ジョブパックの店（markdown を貼るだけ。Claude Code と ChatGPT のパックもあり）。無料パックは無料のまま。有料 Desk 向け USDT TRC20 checkout は公開済み。
 - [grokbot-imessage-skill](https://github.com/jeffhuber/grokbot-imessage-skill) - ローカルの macOS helper 経由で、Bot が iMessage を読み、仕分け、送ります。
 - [Grok Bot Discord gateway](https://github.com/davefmurray/grok-bot-discord) - Slack App のふりをせず、Bot を Discord に住ませるブリッジ。
 - [Werewolf gamemaster skill](https://github.com/Heyvhuang/werewolf-gamemaster) - 本物のスキルパック：hello-world の SKILL.md ではなく、Bot が人狼の進行役をします。
@@ -661,7 +662,7 @@
 
 ## 貢献
 
-8 セクションに 555 件を収録しています。PR の前に [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) を読んでください。対象はクラウドパソコン仲間としての Grok Bot、リンクは開けること、説明は句点で終わる一文です。
+8 セクションに 556 件を収録しています。PR の前に [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) を読んでください。対象はクラウドパソコン仲間としての Grok Bot、リンクは開けること、説明は句点で終わる一文です。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   <a href="https://awesome.re"><img src="https://awesome.re/badge.svg" alt="Awesome" /></a>
-  <img src="https://img.shields.io/badge/entries-555-blueviolet" alt="Entry count" />
+  <img src="https://img.shields.io/badge/entries-556-blueviolet" alt="Entry count" />
   <img src="https://img.shields.io/badge/Grok%20Bot-beta%20(2026--08--11)-informational" alt="Grok Bot status" />
   <img src="https://img.shields.io/badge/license-CC0-lightgrey" alt="License" />
 </p>
@@ -234,6 +234,7 @@
 
 ## Skills, Plugins & MCP
 
+- [Bot Shelf](https://github.com/getbotshelf/botshelf) - Shop of Grok Bot job packs that already ran (copy-paste markdown; Claude Code and ChatGPT packs too). Free packs stay free; USDT TRC20 checkout is live for paid desks.
 - [grokbot-imessage-skill](https://github.com/jeffhuber/grokbot-imessage-skill) - Read, triage, and send iMessage from the Bot via a local macOS helper.
 - [Grok Bot Discord gateway](https://github.com/davefmurray/grok-bot-discord) - Bridge so a Bot can live in Discord without pretending to be a Slack App.
 - [Werewolf gamemaster skill](https://github.com/Heyvhuang/werewolf-gamemaster) - A real skill pack: the Bot runs a Werewolf table, not a hello-world SKILL.md.
@@ -661,7 +662,7 @@
 
 ## Contributing
 
-555 curated entries across 8 sections. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR: the resource must be about Grok Bot the cloud-computer teammate, the link must work, and the blurb is one sentence ending with a period.
+556 curated entries across 8 sections. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR: the resource must be about Grok Bot the cloud-computer teammate, the link must work, and the blurb is one sentence ending with a period.
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   <a href="https://awesome.re"><img src="https://awesome.re/badge.svg" alt="Awesome" /></a>
-  <img src="https://img.shields.io/badge/entries-555-blueviolet" alt="Entry count" />
+  <img src="https://img.shields.io/badge/entries-556-blueviolet" alt="Entry count" />
   <img src="https://img.shields.io/badge/Grok%20Bot-beta%20(2026--08--11)-informational" alt="Grok Bot status" />
   <img src="https://img.shields.io/badge/license-CC0-lightgrey" alt="License" />
 </p>
@@ -234,6 +234,7 @@
 
 ## 技能、插件与 MCP
 
+- [Bot Shelf](https://github.com/getbotshelf/botshelf) - 已经跑过的 Grok Bot 工作包商店（markdown 可粘贴；也有 Claude Code 和 ChatGPT 包）。免费包保持免费；付费 Desk 的 USDT TRC20 checkout 已上线.
 - [grokbot-imessage-skill](https://github.com/jeffhuber/grokbot-imessage-skill) - 通过本机 macOS helper 让 Bot 读、分拣、发 iMessage。.
 - [Grok Bot Discord gateway](https://github.com/davefmurray/grok-bot-discord) - Discord 网关：让 Bot 住在 Discord，而不是假装 Slack App。.
 - [Werewolf gamemaster skill](https://github.com/Heyvhuang/werewolf-gamemaster) - 真技能包：Bot 当狼人杀主持人，不是 hello-world SKILL.md。.
@@ -661,7 +662,7 @@
 
 ## 贡献
 
-目前 8 个分类、555 条精选。提交前请读 [CONTRIBUTING.md](CONTRIBUTING.md)：必须是云电脑队友这个产品、链接能打开、一句话说明、句号结尾。
+目前 8 个分类、556 条精选。提交前请读 [CONTRIBUTING.md](CONTRIBUTING.md)：必须是云电脑队友这个产品、链接能打开、一句话说明、句号结尾。
 
 ---
 

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -1476,6 +1476,16 @@
       },
       "items": [
         {
+          "title": "Bot Shelf",
+          "url": "https://github.com/getbotshelf/botshelf",
+          "source": "pr-getbotshelf-20260906-readd",
+          "blurb": {
+            "en": "Shop of Grok Bot job packs that already ran (copy-paste markdown; Claude Code and ChatGPT packs too). Free packs stay free; USDT TRC20 checkout is live for paid desks.",
+            "zh": "已经跑过的 Grok Bot 工作包商店（markdown 可粘贴；也有 Claude Code 和 ChatGPT 包）。免费包保持免费；付费 Desk 的 USDT TRC20 checkout 已上线",
+            "ja": "すでに走った Grok Bot ジョブパックの店（markdown を貼るだけ。Claude Code と ChatGPT のパックもあり）。無料パックは無料のまま。有料 Desk 向け USDT TRC20 checkout は公開済み"
+          }
+        },
+        {
           "title": "grokbot-imessage-skill",
           "url": "https://github.com/jeffhuber/grokbot-imessage-skill",
           "source": "GB-183",


### PR DESCRIPTION
## New resource

- [Bot Shelf](https://github.com/getbotshelf/botshelf) - Shop of Grok Bot job packs that already ran (copy-paste markdown; Claude Code and ChatGPT packs too). Free packs stay free; USDT TRC20 checkout is live for paid desks.

## Checklist

- [x] About Grok Bot the cloud-computer teammate (not grok.com chat / Imagine / 4.x)
- [x] I opened the link
- [x] `data/catalog.json` has `en` + `zh` + `ja` blurbs
- [x] `python3 scripts/generate_readme.py` was run
- [x] No duplicate URL

## Notes

Earlier PR #5 added Bot Shelf; the entry later dropped from upstream `catalog.json` during list growth. This restores it under **Skills, Plugins & MCP** with an accurate blurb (USDT TRC20 checkout is live; free packs stay free). No pricing dollar claims.