### PR TITLE
Add Grok Bot Templates (grokbottemplates.dev)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   <a href="https://awesome.re"><img src="https://awesome.re/badge.svg" alt="Awesome" /></a>
-  <img src="https://img.shields.io/badge/entries-570-blueviolet" alt="Entry count" />
+  <img src="https://img.shields.io/badge/entries-571-blueviolet" alt="Entry count" />
   <img src="https://img.shields.io/badge/Grok%20Bot-beta%20(2026--08--11)-informational" alt="Grok Bot status" />
   <img src="https://img.shields.io/badge/license-CC0-lightgrey" alt="License" />
 </p>
@@ -673,10 +673,11 @@
 - [Awesome Grok Bot curated list](https://github.com/doanbactam/awesome-grok-bots) - 非公式キュレーション。Grok Bot のテンプレ・スキル・プラグイン・ツール。一次ソース必須。
 - [Grok Bot Voice Android hold-to-talk](https://github.com/jmtroller/grok-bot-voice) - Kotlin 製長押し通話 Android アプリ。端末はマイク/スピーカー、脳は MCP 経由の Grok Bot。
 - [Buzz relay ears webhook for Grok Bot](https://github.com/0xnfrith/grokbot-buzz-ears) - 小型フォワーダ。Bot 鍵で Buzz / Nostr NIP-29 に入り、メンションでエージェント HTTP webhook を起こす。
+- [Grok Bot Templates](https://grokbottemplates.dev/) - 独立系 Grok Bot テンプレート一覧。仕事内容、同梱物、要求されるアクセス、共有者を明示。
 
 ## 貢献
 
-8 セクションに 570 件を収録しています。PR の前に [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) を読んでください。対象はクラウドパソコン仲間としての Grok Bot、リンクは開けること、説明は句点で終わる一文です。
+8 セクションに 571 件を収録しています。PR の前に [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) を読んでください。対象はクラウドパソコン仲間としての Grok Bot、リンクは開けること、説明は句点で終わる一文です。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   <a href="https://awesome.re"><img src="https://awesome.re/badge.svg" alt="Awesome" /></a>
-  <img src="https://img.shields.io/badge/entries-570-blueviolet" alt="Entry count" />
+  <img src="https://img.shields.io/badge/entries-571-blueviolet" alt="Entry count" />
   <img src="https://img.shields.io/badge/Grok%20Bot-beta%20(2026--08--11)-informational" alt="Grok Bot status" />
   <img src="https://img.shields.io/badge/license-CC0-lightgrey" alt="License" />
 </p>
@@ -673,10 +673,11 @@
 - [Awesome Grok Bot curated list](https://github.com/doanbactam/awesome-grok-bots) - Unofficial curated list of Grok Bot templates, skills, plugins, and tools with primary-source requirements.
 - [Grok Bot Voice Android hold-to-talk](https://github.com/jmtroller/grok-bot-voice) - Native Kotlin hold-to-talk Android app that uses the phone as mic/speaker while a Grok Bot stays the brain over MCP.
 - [Buzz relay ears webhook for Grok Bot](https://github.com/0xnfrith/grokbot-buzz-ears) - Small forwarder that signs into Buzz/Nostr NIP-29 groups with the bot key and wakes an agent HTTP webhook on mentions.
+- [Grok Bot Templates](https://grokbottemplates.dev/) - Independent directory of Grok Bot templates that shows each job, what the pack includes, the access it asks for, and who shared it.
 
 ## Contributing
 
-570 curated entries across 8 sections. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR: the resource must be about Grok Bot the cloud-computer teammate, the link must work, and the blurb is one sentence ending with a period.
+571 curated entries across 8 sections. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR: the resource must be about Grok Bot the cloud-computer teammate, the link must work, and the blurb is one sentence ending with a period.
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   <a href="https://awesome.re"><img src="https://awesome.re/badge.svg" alt="Awesome" /></a>
-  <img src="https://img.shields.io/badge/entries-570-blueviolet" alt="Entry count" />
+  <img src="https://img.shields.io/badge/entries-571-blueviolet" alt="Entry count" />
   <img src="https://img.shields.io/badge/Grok%20Bot-beta%20(2026--08--11)-informational" alt="Grok Bot status" />
   <img src="https://img.shields.io/badge/license-CC0-lightgrey" alt="License" />
 </p>
@@ -673,10 +673,11 @@
 - [Awesome Grok Bot curated list](https://github.com/doanbactam/awesome-grok-bots) - 非官方精选：Grok Bot 模板、技能、插件与工具，要求有一手来源。.
 - [Grok Bot Voice Android hold-to-talk](https://github.com/jmtroller/grok-bot-voice) - 原生 Kotlin Android 按住说话应用：手机当麦克风/扬声器，Grok Bot 经 MCP 做大脑。.
 - [Buzz relay ears webhook for Grok Bot](https://github.com/0xnfrith/grokbot-buzz-ears) - 小型转发器：用 Bot 密钥登录 Buzz/Nostr NIP-29 群，提及时唤醒智能体 HTTP webhook。.
+- [Grok Bot Templates](https://grokbottemplates.dev/) - 独立的 Grok Bot 模板目录：展示每个岗位、模板包含内容、所需权限以及分享者。.
 
 ## 贡献
 
-目前 8 个分类、570 条精选。提交前请读 [CONTRIBUTING.md](CONTRIBUTING.md)：必须是云电脑队友这个产品、链接能打开、一句话说明、句号结尾。
+目前 8 个分类、571 条精选。提交前请读 [CONTRIBUTING.md](CONTRIBUTING.md)：必须是云电脑队友这个产品、链接能打开、一句话说明、句号结尾。
 
 ---
 

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -5784,6 +5784,16 @@
             "zh": "小型转发器：用 Bot 密钥登录 Buzz/Nostr NIP-29 群，提及时唤醒智能体 HTTP webhook。",
             "ja": "小型フォワーダ。Bot 鍵で Buzz / Nostr NIP-29 に入り、メンションでエージェント HTTP webhook を起こす。"
           }
+        },
+        {
+          "title": "Grok Bot Templates",
+          "url": "https://grokbottemplates.dev/",
+          "source": "GB-594",
+          "blurb": {
+            "en": "Independent directory of Grok Bot templates that shows each job, what the pack includes, the access it asks for, and who shared it.",
+            "zh": "独立的 Grok Bot 模板目录：展示每个岗位、模板包含内容、所需权限以及分享者。",
+            "ja": "独立系 Grok Bot テンプレート一覧。仕事内容、同梱物、要求されるアクセス、共有者を明示。"
+          }
         }
       ]
     }


### PR DESCRIPTION
## Summary
Adds [Grok Bot Templates](https://grokbottemplates.dev/) to **Related Lists**.

Independent hosted directory of Grok Bot templates. Each listing shows the job, what the pack includes, the access it asks for, and who shared it — useful alongside usegrokbot.com and other template catalogs already in this section.

## Checklist
- [x] About Grok Bot the cloud-computer product (template directory for named Bots)
- [x] URL reachable (https://grokbottemplates.dev/)
- [x] One-sentence blurb ending with a period (en/zh/ja in `data/catalog.json`)
- [x] Regenerated README.md / README.zh.md / README.ja.md via `scripts/generate_readme.py`
- [x] Not a duplicate URL

## Affiliation
I am Wayde Lyle (@waydelyle), owner of grokbottemplates.dev.